### PR TITLE
Add Registered domain policies

### DIFF
--- a/docs/policies/enforce_auto_renew_state.md
+++ b/docs/policies/enforce_auto_renew_state.md
@@ -1,0 +1,24 @@
+# Enforce Auto Renew State
+
+| Provider | Category           |
+| -------- | ------------------ |
+| DNSimple | Network Automation |
+
+## Overview
+Enforcing the auto renew state on a domain ensures that the domain is automatically renewed before it expires and is not lost. This policy checks that the auto renew state is set, to your expected value.
+
+## Parameter Reference
+
+The following parameter(s) are supported:
+
+* `auto_renew_state` - (Boolean) The state of the domain auto renew state you want to enforce. (default: `true`)
+* `auto_renew_enforced_domain_names` - (List) The list of domains to enforce the policy. Leave as empty list to apply to all domains. (default: `[]`)
+
+## Policy Result (Pass)
+
+```bash
+trace:
+      enforce_auto_renew_state.sentinel:59:1 - Rule "main"
+        Value:
+          true
+```

--- a/docs/policies/enforce_contact_id.md
+++ b/docs/policies/enforce_contact_id.md
@@ -1,0 +1,59 @@
+# Enforce Contact ID
+
+| Provider | Category           |
+| -------- | ------------------ |
+| DNSimple | Network Automation |
+
+## Overview
+Enforcing the contact id for a domain allows you to ensure that the domain is registered with the correct contact. This policy checks that the contact id is set, to an allowed value.
+
+## Parameter Reference
+
+The following parameter(s) are supported:
+
+* `allowed_contact_ids` - (List) The list of contact ids to allow. (required)
+* `contact_id_enforced_domain_names` - (List) The list of domains to enforce the policy. Leave as empty list to apply to all domains. (default: `[]`)
+
+## Policy Result (Pass)
+
+```bash
+trace:
+      enforce_contact_id.sentinel:59:1 - Rule "main"
+        Value:
+          true
+```
+
+## Policy Result (Failure)
+
+```bash
+logs:
+  	========================================================================
+   	Name        : enforce_contact_id.sentinel
+   	Provider    : dnsimple/dnsimple
+   	Resource    : dnsimple_registered_domain
+   	Parameter   : contact_id
+   	========================================================================
+   	For a list of allowed parameter options see:
+   	https://github.com/dnsimple/policy-library-dnsimple-terraform/blob/main/README.md
+
+  	========================================================================
+   	RESOURCE VIOLATIONS
+   	The domain contact_id should be in 1, 2.
+   	========================================================================
+  	 name       : instance
+  	 type       : dnsimple_registered_domain
+  	 address    : dnsimple_registered_domain.test
+  	 message    : 10030 is not an allowed contact id.
+   	------------------------------------------------------------------------
+  	 name       : instance
+  	 type       : dnsimple_registered_domain
+  	 address    : dnsimple_registered_domain.test_2
+  	 message    : 10230 is not an allowed contact id.
+   	------------------------------------------------------------------------
+  	 Resources out of compliance: 2
+   	------------------------------------------------------------------------
+trace:
+  enforce_contact_id.sentinel:61:1 - Rule "main"
+    Value:
+      false
+```

--- a/docs/policies/enforce_dnssec_state.md
+++ b/docs/policies/enforce_dnssec_state.md
@@ -1,0 +1,25 @@
+# Enforce DNSSEC State
+
+| Provider | Category           |
+| -------- | ------------------ |
+| DNSimple | Network Automation |
+
+## Overview
+Enforcing the dnssec state on a domain ensures that the domain is secured with DNSSEC. This policy checks that the dnssec state is set, to your expected value.
+
+## Parameter Reference
+
+The following parameter(s) are supported:
+
+* `dnssec_state` - (Boolean) The state of the domain dnssec state you want to enforce. (default: `true`)
+* `dnssec_enforced_domain_names` - (List) The list of domains to enforce the policy. Leave as empty list to apply to all domains. (default: `[]`)
+* `dnssec_enforced_domain_tlds` - (List) The list of domain TLDs to exclude from enforcing the policy, as some TLDs do not support DNSSEC. Leave as empty list to apply to all TLDs. (default: `[]`)
+
+## Policy Result (Pass)
+
+```bash
+trace:
+      enforce_dnssec_state.sentinel:59:1 - Rule "main"
+        Value:
+          true
+```

--- a/docs/policies/enforce_whois_privacy_state.md
+++ b/docs/policies/enforce_whois_privacy_state.md
@@ -1,0 +1,25 @@
+# Enforce Whois Privacy State
+
+| Provider | Category           |
+| -------- | ------------------ |
+| DNSimple | Network Automation |
+
+## Overview
+Enforcing the whois privacy state on a domain is a privacy feature offered by some TLDs. This policy checks that the whois privacy state is set, to your expected value.
+
+## Parameter Reference
+
+The following parameter(s) are supported:
+
+* `whois_privacy_state` - (Boolean) The state of the domain transfer lock state you want to enforce. (default: `true`)
+* `whois_privacy_enforced_domain_names` - (List) The list of domains to enforce the policy. Leave as empty list to apply to all domains. (default: `[]`)
+* `whois_privacy_enforced_domain_tlds` - (List) The list of domain TLDs to exclude from enforcing the policy. Leave as empty list to apply to all TLDs. (default: `[]`)
+
+## Policy Result (Pass)
+
+```bash
+trace:
+      enforce_whois_privacy_state.sentinel:59:1 - Rule "main"
+        Value:
+          true
+```

--- a/docs/policies/enforce_whois_privacy_state.md
+++ b/docs/policies/enforce_whois_privacy_state.md
@@ -13,7 +13,7 @@ The following parameter(s) are supported:
 
 * `whois_privacy_state` - (Boolean) The state of the domain transfer lock state you want to enforce. (default: `true`)
 * `whois_privacy_enforced_domain_names` - (List) The list of domains to enforce the policy. Leave as empty list to apply to all domains. (default: `[]`)
-* `whois_privacy_enforced_domain_tlds` - (List) The list of domain TLDs to exclude from enforcing the policy. Leave as empty list to apply to all TLDs. (default: `[]`)
+* `whois_privacy_enforced_domain_tlds` - (List) The list of domain TLDs to exclude from enforcing the policy, as some TLDs do not support Whois Privacy. Leave as empty list to apply to all TLDs. (default: `[]`)
 
 ## Policy Result (Pass)
 

--- a/policies/enforce_auto_renew_state/enforce_auto_renew_state.sentinel
+++ b/policies/enforce_auto_renew_state/enforce_auto_renew_state.sentinel
@@ -1,0 +1,61 @@
+import "tfplan/v2" as tfplan
+import "helpers"
+
+param valid_actions default [
+	["no-op"],
+	["create"],
+	["update"],
+]
+
+// The enforced auto renewal state
+param auto_renew_state default true
+
+// A list of domain names that should have auto renewal enforced
+param auto_renew_enforced_domain_names default []
+
+doc = {
+	"allowed":   auto_renew_state,
+	"error":     " is not an allowed auto_renew_enabled state.",
+	"file_name": "enforce_auto_renew_state.sentinel",
+	"name":      "Enforeced Domain Auto Renew State",
+	"md_url":    "https://github.com/dnsimple/policy-library-dnsimple-terraform/blob/main/README.md",
+	"parameter": "auto_renew_enabled",
+	"provider":  "dnsimple/dnsimple",
+	"resource":  "dnsimple_registered_domain",
+	"violation": "The domain auto_renew_enabled state should be ${auto_renew_state}",
+}
+
+// Filter resources by type
+all_resources = filter tfplan.resource_changes as _, rc {
+	rc.type is doc.resource and
+		rc.mode is "managed" and
+		rc.change.actions in valid_actions
+}
+
+if (length(auto_renew_enforced_domain_names) else 0) > 0 {
+	all_resources = filter all_resources as _, r {
+		r.change.after.name in auto_renew_enforced_domain_names
+	}
+}
+
+// Filter resources that violate a given condition
+violators = filter all_resources as _, r {
+	r.change.after.auto_renew_enabled != auto_renew_state
+}
+
+// Build a summary report
+summaryreport = {
+	"name": doc.name,
+	"violations": map violators as _, violation {
+		{
+			"name":    violation.name,
+			"address": violation.address,
+			"type":    violation.type,
+			"message": string(violation.change.after.auto_renew_enabled) + doc.error,
+		}
+	},
+}
+
+main = rule {
+	helpers.summary(summaryreport, doc)
+}

--- a/policies/enforce_auto_renew_state/test/enforce_auto_renew_state/failure-with-params.hcl
+++ b/policies/enforce_auto_renew_state/test/enforce_auto_renew_state/failure-with-params.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-failure.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "transfer_lock_enforced_domain_names" {
+  value = [
+    "example-2.com"
+  ]
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/enforce_auto_renew_state/test/enforce_auto_renew_state/failure.hcl
+++ b/policies/enforce_auto_renew_state/test/enforce_auto_renew_state/failure.hcl
@@ -1,0 +1,15 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-failure.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/enforce_auto_renew_state/test/enforce_auto_renew_state/success-with-params.hcl
+++ b/policies/enforce_auto_renew_state/test/enforce_auto_renew_state/success-with-params.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-success.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "transfer_lock_enforced_domain_names" {
+  value = [
+    "example-2.com"
+  ]
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/policies/enforce_auto_renew_state/test/enforce_auto_renew_state/success.hcl
+++ b/policies/enforce_auto_renew_state/test/enforce_auto_renew_state/success.hcl
@@ -1,0 +1,15 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-success.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/policies/enforce_auto_renew_state/testdata/mock-tfplan-failure.sentinel
+++ b/policies/enforce_auto_renew_state/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,60 @@
+terraform_version = "1.5.6"
+
+resource_changes = {
+	"dnsimple_registered_domain.test": {
+		"address": "dnsimple_registered_domain.test",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    false,
+				"contact_id":            10030,
+				"dnssec_enabled":        false,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example.com",
+				"state":                 null,
+				"transfer_lock_enabled": false,
+				"unicode_name":          null,
+				"whois_privacy_enabled": false,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+	"dnsimple_registered_domain.test_2": {
+		"address": "dnsimple_registered_domain.test_2",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    false,
+				"contact_id":            10030,
+				"dnssec_enabled":        false,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example-2.com",
+				"state":                 null,
+				"transfer_lock_enabled": false,
+				"unicode_name":          null,
+				"whois_privacy_enabled": false,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+}

--- a/policies/enforce_auto_renew_state/testdata/mock-tfplan-success.sentinel
+++ b/policies/enforce_auto_renew_state/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,60 @@
+terraform_version = "1.5.6"
+
+resource_changes = {
+	"dnsimple_registered_domain.test": {
+		"address": "dnsimple_registered_domain.test",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    true,
+				"contact_id":            10030,
+				"dnssec_enabled":        false,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example.com",
+				"state":                 null,
+				"transfer_lock_enabled": true,
+				"unicode_name":          null,
+				"whois_privacy_enabled": false,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+	"dnsimple_registered_domain.test_2": {
+		"address": "dnsimple_registered_domain.test_2",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    true,
+				"contact_id":            10030,
+				"dnssec_enabled":        false,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example-2.com",
+				"state":                 null,
+				"transfer_lock_enabled": true,
+				"unicode_name":          null,
+				"whois_privacy_enabled": false,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+}

--- a/policies/enforce_contact_id/enforce_contact_id.sentinel
+++ b/policies/enforce_contact_id/enforce_contact_id.sentinel
@@ -1,0 +1,63 @@
+import "tfplan/v2" as tfplan
+import "strings"
+import "helpers"
+
+param valid_actions default [
+	["no-op"],
+	["create"],
+	["update"],
+]
+
+// The enforced contact ids
+param allowed_contact_ids
+
+// A list of domain names that should have contact_id enforced
+param contact_id_enforced_domain_names default []
+
+doc = {
+	"allowed":   allowed_contact_ids,
+	"error":     " is not an allowed contact id.",
+	"file_name": "enforce_contact_id.sentinel",
+	"name":      "Enforeced Domain Contact ID",
+	"md_url":    "https://github.com/dnsimple/policy-library-dnsimple-terraform/blob/main/README.md",
+	"parameter": "contact_id",
+	"provider":  "dnsimple/dnsimple",
+	"resource":  "dnsimple_registered_domain",
+	"violation": "The domain contact_id should be in " + strings.join(allowed_contact_ids, ", ") + ".",
+}
+
+// Filter resources by type
+all_resources = filter tfplan.resource_changes as _, rc {
+	rc.type is doc.resource and
+		rc.mode is "managed" and
+		rc.change.actions in valid_actions
+}
+
+// Filter resources by domain name
+if (length(contact_id_enforced_domain_names) else 0) > 0 {
+	all_resources = filter all_resources as _, r {
+		r.change.after.name in contact_id_enforced_domain_names
+	}
+}
+
+// Filter resources that violate a given condition
+violators = filter all_resources as _, r {
+	r.change.after.contact_id not in allowed_contact_ids
+}
+
+// Build a summary report
+summaryreport = {
+	"name": doc.name,
+	"violations": map violators as _, violation {
+		{
+			"name":    violation.name,
+			"address": violation.address,
+			"type":    violation.type,
+			"message": string(violation.change.after.contact_id) + doc.error,
+		}
+	},
+}
+
+main = rule {
+	helpers.summary(summaryreport, doc)
+}

--- a/policies/enforce_contact_id/test/enforce_contact_id/failure-with-domain-name-list-params.hcl
+++ b/policies/enforce_contact_id/test/enforce_contact_id/failure-with-domain-name-list-params.hcl
@@ -1,0 +1,27 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-failure.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "contact_id_enforced_domain_names" {
+  value = [
+    "example-2.eu"
+  ]
+}
+
+param "allowed_contact_ids" {
+  value = [
+    10030,
+  ]
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/enforce_contact_id/test/enforce_contact_id/failure-with-params.hcl
+++ b/policies/enforce_contact_id/test/enforce_contact_id/failure-with-params.hcl
@@ -1,0 +1,22 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-failure.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "allowed_contact_ids" {
+  value = [
+    10230,
+  ]
+}
+
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/enforce_contact_id/test/enforce_contact_id/failure.hcl
+++ b/policies/enforce_contact_id/test/enforce_contact_id/failure.hcl
@@ -1,0 +1,23 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-failure.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "allowed_contact_ids" {
+  value = [
+    1,
+    2,
+  ]
+}
+
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/enforce_contact_id/test/enforce_contact_id/success-with-domain-name-list-params.hcl
+++ b/policies/enforce_contact_id/test/enforce_contact_id/success-with-domain-name-list-params.hcl
@@ -1,0 +1,27 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-success.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "contact_id_enforced_domain_names" {
+  value = [
+    "example-2.eu"
+  ]
+}
+
+param "allowed_contact_ids" {
+  value = [
+    10230,
+  ]
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/policies/enforce_contact_id/test/enforce_contact_id/success.hcl
+++ b/policies/enforce_contact_id/test/enforce_contact_id/success.hcl
@@ -1,0 +1,22 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-success.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "allowed_contact_ids" {
+  value = [
+    10030,
+    10230,
+  ]
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/policies/enforce_contact_id/testdata/mock-tfplan-failure.sentinel
+++ b/policies/enforce_contact_id/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,60 @@
+terraform_version = "1.5.6"
+
+resource_changes = {
+	"dnsimple_registered_domain.test": {
+		"address": "dnsimple_registered_domain.test",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    false,
+				"contact_id":            10030,
+				"dnssec_enabled":        false,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example.com",
+				"state":                 null,
+				"transfer_lock_enabled": false,
+				"unicode_name":          null,
+				"whois_privacy_enabled": false,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+	"dnsimple_registered_domain.test_2": {
+		"address": "dnsimple_registered_domain.test_2",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    false,
+				"contact_id":            10230,
+				"dnssec_enabled":        false,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example-2.eu",
+				"state":                 null,
+				"transfer_lock_enabled": false,
+				"unicode_name":          null,
+				"whois_privacy_enabled": false,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+}

--- a/policies/enforce_contact_id/testdata/mock-tfplan-success.sentinel
+++ b/policies/enforce_contact_id/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,60 @@
+terraform_version = "1.5.6"
+
+resource_changes = {
+	"dnsimple_registered_domain.test": {
+		"address": "dnsimple_registered_domain.test",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    true,
+				"contact_id":            10030,
+				"dnssec_enabled":        true,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example.com",
+				"state":                 null,
+				"transfer_lock_enabled": true,
+				"unicode_name":          null,
+				"whois_privacy_enabled": true,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+	"dnsimple_registered_domain.test_2": {
+		"address": "dnsimple_registered_domain.test_2",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    true,
+				"contact_id":            10230,
+				"dnssec_enabled":        true,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example-2.eu",
+				"state":                 null,
+				"transfer_lock_enabled": true,
+				"unicode_name":          null,
+				"whois_privacy_enabled": true,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+}

--- a/policies/enforce_dnssec_state/enforce_dnssec_state.sentinel
+++ b/policies/enforce_dnssec_state/enforce_dnssec_state.sentinel
@@ -1,0 +1,76 @@
+import "tfplan/v2" as tfplan
+import "strings"
+import "helpers"
+
+param valid_actions default [
+	["no-op"],
+	["create"],
+	["update"],
+]
+
+// The enforced dnssec state
+param dnssec_state default true
+
+// A list of domain names that should have dnssec enforced
+param dnssec_enforced_domain_names default []
+
+// A list of TLDs that should be excluded from the enforcement
+param dnssec_enforced_domain_tlds default []
+
+doc = {
+	"allowed":   dnssec_state,
+	"error":     " is not an allowed dnssec_enabled state.",
+	"file_name": "enforce_dnssec_state.sentinel",
+	"name":      "Enforeced Domain DNSSEC State",
+	"md_url":    "https://github.com/dnsimple/policy-library-dnsimple-terraform/blob/main/README.md",
+	"parameter": "dnssec_enabled",
+	"provider":  "dnsimple/dnsimple",
+	"resource":  "dnsimple_registered_domain",
+	"violation": "The domain dnssec_enabled state should be ${dnssec_state}",
+}
+
+// Filter resources by type
+all_resources = filter tfplan.resource_changes as _, rc {
+	rc.type is doc.resource and
+		rc.mode is "managed" and
+		rc.change.actions in valid_actions
+}
+
+// Filter resources by TLD
+if (length(dnssec_enforced_domain_tlds) else 0) > 0 {
+	all_resources = filter all_resources as _, r {
+		// Check if the domain name ends with any of the TLDs
+		all dnssec_enforced_domain_tlds as _, tld {
+			!strings.has_suffix(r.change.after.name, strings.to_lower(tld))
+		}
+	}
+}
+
+// Filter resources by domain name
+if (length(dnssec_enforced_domain_names) else 0) > 0 {
+	all_resources = filter all_resources as _, r {
+		r.change.after.name in dnssec_enforced_domain_names
+	}
+}
+
+// Filter resources that violate a given condition
+violators = filter all_resources as _, r {
+	r.change.after.dnssec_enabled != dnssec_state
+}
+
+// Build a summary report
+summaryreport = {
+	"name": doc.name,
+	"violations": map violators as _, violation {
+		{
+			"name":    violation.name,
+			"address": violation.address,
+			"type":    violation.type,
+			"message": string(violation.change.after.dnssec_enabled) + doc.error,
+		}
+	},
+}
+
+main = rule {
+	helpers.summary(summaryreport, doc)
+}

--- a/policies/enforce_dnssec_state/test/enforce_dnssec_state/failure-with-domain-name-list-params.hcl
+++ b/policies/enforce_dnssec_state/test/enforce_dnssec_state/failure-with-domain-name-list-params.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-failure.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "dnssec_enforced_domain_names" {
+  value = [
+    "example-2.eu"
+  ]
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/enforce_dnssec_state/test/enforce_dnssec_state/failure-with-domain-tld-list-params.hcl
+++ b/policies/enforce_dnssec_state/test/enforce_dnssec_state/failure-with-domain-tld-list-params.hcl
@@ -1,0 +1,22 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-failure.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "dnssec_enforced_domain_tlds" {
+  value = [
+    ".EU",
+    ".DE",
+  ]
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/enforce_dnssec_state/test/enforce_dnssec_state/failure.hcl
+++ b/policies/enforce_dnssec_state/test/enforce_dnssec_state/failure.hcl
@@ -1,0 +1,15 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-failure.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/enforce_dnssec_state/test/enforce_dnssec_state/success-with-domain-name-list-params.hcl
+++ b/policies/enforce_dnssec_state/test/enforce_dnssec_state/success-with-domain-name-list-params.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-success.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "whois_privacy_enforced_domain_names" {
+  value = [
+    "example-2.eu"
+  ]
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/policies/enforce_dnssec_state/test/enforce_dnssec_state/success.hcl
+++ b/policies/enforce_dnssec_state/test/enforce_dnssec_state/success.hcl
@@ -1,0 +1,15 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-success.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/policies/enforce_dnssec_state/testdata/mock-tfplan-failure.sentinel
+++ b/policies/enforce_dnssec_state/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,60 @@
+terraform_version = "1.5.6"
+
+resource_changes = {
+	"dnsimple_registered_domain.test": {
+		"address": "dnsimple_registered_domain.test",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    false,
+				"contact_id":            10030,
+				"dnssec_enabled":        false,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example.com",
+				"state":                 null,
+				"transfer_lock_enabled": false,
+				"unicode_name":          null,
+				"whois_privacy_enabled": false,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+	"dnsimple_registered_domain.test_2": {
+		"address": "dnsimple_registered_domain.test_2",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    false,
+				"contact_id":            10030,
+				"dnssec_enabled":        false,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example-2.eu",
+				"state":                 null,
+				"transfer_lock_enabled": false,
+				"unicode_name":          null,
+				"whois_privacy_enabled": false,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+}

--- a/policies/enforce_dnssec_state/testdata/mock-tfplan-success.sentinel
+++ b/policies/enforce_dnssec_state/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,60 @@
+terraform_version = "1.5.6"
+
+resource_changes = {
+	"dnsimple_registered_domain.test": {
+		"address": "dnsimple_registered_domain.test",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    true,
+				"contact_id":            10030,
+				"dnssec_enabled":        true,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example.com",
+				"state":                 null,
+				"transfer_lock_enabled": true,
+				"unicode_name":          null,
+				"whois_privacy_enabled": true,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+	"dnsimple_registered_domain.test_2": {
+		"address": "dnsimple_registered_domain.test_2",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    true,
+				"contact_id":            10030,
+				"dnssec_enabled":        true,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example-2.eu",
+				"state":                 null,
+				"transfer_lock_enabled": true,
+				"unicode_name":          null,
+				"whois_privacy_enabled": true,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+}

--- a/policies/enforce_transfer_lock_state/enforce_transfer_lock_state.sentinel
+++ b/policies/enforce_transfer_lock_state/enforce_transfer_lock_state.sentinel
@@ -18,7 +18,7 @@ doc = {
 	"error":     " is not an allowed transfer_lock_enabled state.",
 	"file_name": "enforce_transfer_lock_state.sentinel",
 	"name":      "Enforeced Domain Transfer Lock State",
-	"md_url":    "https://github.com/dnsimple/terraform-intel-gcp-vm/blob/main/policies.md",
+	"md_url":    "https://github.com/dnsimple/policy-library-dnsimple-terraform/blob/main/README.md",
 	"parameter": "transfer_lock_enabled",
 	"provider":  "dnsimple/dnsimple",
 	"resource":  "dnsimple_registered_domain",

--- a/policies/enforce_whois_privacy_state/enforce_whois_privacy_state.sentinel
+++ b/policies/enforce_whois_privacy_state/enforce_whois_privacy_state.sentinel
@@ -1,0 +1,76 @@
+import "tfplan/v2" as tfplan
+import "strings"
+import "helpers"
+
+param valid_actions default [
+	["no-op"],
+	["create"],
+	["update"],
+]
+
+// The enforced whois privacy state
+param whois_privacy_state default true
+
+// A list of domain names that should have whois privacy enforced
+param whois_privacy_enforced_domain_names default []
+
+// A list of TLDs that should be excluded from the enforcement
+param whois_privacy_enforced_domain_tlds default []
+
+doc = {
+	"allowed":   whois_privacy_state,
+	"error":     " is not an allowed whois_privacy_enabled state.",
+	"file_name": "enforce_whois_privacy_state.sentinel",
+	"name":      "Enforeced Domain Whois Privacy State",
+	"md_url":    "https://github.com/dnsimple/policy-library-dnsimple-terraform/blob/main/README.md",
+	"parameter": "whois_privacy_enabled",
+	"provider":  "dnsimple/dnsimple",
+	"resource":  "dnsimple_registered_domain",
+	"violation": "The domain whois_privacy_enabled state should be ${whois_privacy_state}",
+}
+
+// Filter resources by type
+all_resources = filter tfplan.resource_changes as _, rc {
+	rc.type is doc.resource and
+		rc.mode is "managed" and
+		rc.change.actions in valid_actions
+}
+
+// Filter resources by TLD
+if (length(whois_privacy_enforced_domain_tlds) else 0) > 0 {
+	all_resources = filter all_resources as _, r {
+		// Check if the domain name ends with any of the TLDs
+		all whois_privacy_enforced_domain_tlds as _, tld {
+			!strings.has_suffix(r.change.after.name, strings.to_lower(tld))
+		}
+	}
+}
+
+// Filter resources by domain name
+if (length(whois_privacy_enforced_domain_names) else 0) > 0 {
+	all_resources = filter all_resources as _, r {
+		r.change.after.name in whois_privacy_enforced_domain_names
+	}
+}
+
+// Filter resources that violate a given condition
+violators = filter all_resources as _, r {
+	r.change.after.whois_privacy_enabled != whois_privacy_state
+}
+
+// Build a summary report
+summaryreport = {
+	"name": doc.name,
+	"violations": map violators as _, violation {
+		{
+			"name":    violation.name,
+			"address": violation.address,
+			"type":    violation.type,
+			"message": string(violation.change.after.whois_privacy_enabled) + doc.error,
+		}
+	},
+}
+
+main = rule {
+	helpers.summary(summaryreport, doc)
+}

--- a/policies/enforce_whois_privacy_state/test/enforce_whois_privacy_state/failure-with-domain-name-list-params.hcl
+++ b/policies/enforce_whois_privacy_state/test/enforce_whois_privacy_state/failure-with-domain-name-list-params.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-failure.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "whois_privacy_enforced_domain_names" {
+  value = [
+    "example-2.eu"
+  ]
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/enforce_whois_privacy_state/test/enforce_whois_privacy_state/failure-with-domain-tld-list-params.hcl
+++ b/policies/enforce_whois_privacy_state/test/enforce_whois_privacy_state/failure-with-domain-tld-list-params.hcl
@@ -1,0 +1,22 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-failure.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "whois_privacy_enforced_domain_tlds" {
+  value = [
+    ".EU",
+    ".BE",
+  ]
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/enforce_whois_privacy_state/test/enforce_whois_privacy_state/failure.hcl
+++ b/policies/enforce_whois_privacy_state/test/enforce_whois_privacy_state/failure.hcl
@@ -1,0 +1,15 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-failure.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/enforce_whois_privacy_state/test/enforce_whois_privacy_state/success-with-domain-name-list-params.hcl
+++ b/policies/enforce_whois_privacy_state/test/enforce_whois_privacy_state/success-with-domain-name-list-params.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-success.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "whois_privacy_enforced_domain_names" {
+  value = [
+    "example-2.eu"
+  ]
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/policies/enforce_whois_privacy_state/test/enforce_whois_privacy_state/success.hcl
+++ b/policies/enforce_whois_privacy_state/test/enforce_whois_privacy_state/success.hcl
@@ -1,0 +1,15 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-success.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/policies/enforce_whois_privacy_state/testdata/mock-tfplan-failure.sentinel
+++ b/policies/enforce_whois_privacy_state/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,60 @@
+terraform_version = "1.5.6"
+
+resource_changes = {
+	"dnsimple_registered_domain.test": {
+		"address": "dnsimple_registered_domain.test",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    false,
+				"contact_id":            10030,
+				"dnssec_enabled":        false,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example.com",
+				"state":                 null,
+				"transfer_lock_enabled": false,
+				"unicode_name":          null,
+				"whois_privacy_enabled": false,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+	"dnsimple_registered_domain.test_2": {
+		"address": "dnsimple_registered_domain.test_2",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    false,
+				"contact_id":            10030,
+				"dnssec_enabled":        false,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example-2.eu",
+				"state":                 null,
+				"transfer_lock_enabled": false,
+				"unicode_name":          null,
+				"whois_privacy_enabled": false,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+}

--- a/policies/enforce_whois_privacy_state/testdata/mock-tfplan-success.sentinel
+++ b/policies/enforce_whois_privacy_state/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,60 @@
+terraform_version = "1.5.6"
+
+resource_changes = {
+	"dnsimple_registered_domain.test": {
+		"address": "dnsimple_registered_domain.test",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    true,
+				"contact_id":            10030,
+				"dnssec_enabled":        false,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example.com",
+				"state":                 null,
+				"transfer_lock_enabled": true,
+				"unicode_name":          null,
+				"whois_privacy_enabled": true,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+	"dnsimple_registered_domain.test_2": {
+		"address": "dnsimple_registered_domain.test_2",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"account_id":            null,
+				"auto_renew_enabled":    true,
+				"contact_id":            10030,
+				"dnssec_enabled":        false,
+				"expires_at":            null,
+				"id":                    null,
+				"name":                  "example-2.eu",
+				"state":                 null,
+				"transfer_lock_enabled": true,
+				"unicode_name":          null,
+				"whois_privacy_enabled": true,
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_registered_domain",
+	},
+}


### PR DESCRIPTION
This PR introduces 4 new policies to allow developers to build a compliance framework for domains managed at DNSimple.

- [enforce_whois_privacy_state policy](https://github.com/dnsimple/policy-library-dnsimple-terraform/commit/fa167375e8710a1f1f36f39db3b8eddb284a6028)
- [enforce_whois_privacy_state policy](https://github.com/dnsimple/policy-library-dnsimple-terraform/commit/fa167375e8710a1f1f36f39db3b8eddb284a6028)
- [enforce_dnssec_state policy](https://github.com/dnsimple/policy-library-dnsimple-terraform/commit/1602d805551b9e741a6fa90488f795762251149a)
- [enforce_contact_id policy](https://github.com/dnsimple/policy-library-dnsimple-terraform/commit/8fa1c192353a51bc40a6d82c3b7e31b839e3098e)

Reviewer notes:
I suggest reviewing the individual commits as policies are self-contained.

Belongs to https://github.com/dnsimple/dnsimple-marketing/issues/619
Belongs to https://github.com/dnsimple/dnsimple-external-integrations/issues/11