### PR TITLE
Enforce domain delegation policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## main
 
+## 0.3.0 (Unreleased)
+
+FEATURES:
+
+- **New Policy:** `enforce_domain_delegation` (dnsimple/policy-library-dnsimple-terraform#2)
+
 ## 0.2.0
 
 FEATURES:

--- a/docs/policies/enforce_domain_delegation.md
+++ b/docs/policies/enforce_domain_delegation.md
@@ -1,0 +1,59 @@
+# Enforce Domain Delegation
+
+| Provider | Category           |
+| -------- | ------------------ |
+| DNSimple | Network Automation |
+
+## Overview
+Enforcing the domain delegation policy ensures that the domain name servers are set to the name servers that you expect. This policy is useful for ensuring that the domain is not delegated to another DNS provider by mistake or by a malicious actor.
+
+## Parameter Reference
+
+The following parameter(s) are supported:
+
+* `allowed_delegation_records` - (List) The list of the allowed name server records. If a domain delegation resource contains an entry that is not in the list the policy enforcement will trigger. (default: `["ns1.dnsimple.com", "ns2.dnsimple.com", "ns3.dnsimple.com", "ns4.dnsimple-edge.org"]`)
+* `domain_delegation_enforced_domain_names` - (List) The list of domains to enforce the policy. Leave as empty list to apply to all domains. (default: `[]`)
+
+## Policy Result (Pass)
+
+```bash
+trace:
+      enforce_domain_delegation.sentinel:77:1 - Rule "main"
+        Value:
+          true
+```
+
+## Policy Result (Failure)
+
+```bash
+logs:
+  	========================================================================
+   	Name        : enforce_domain_delegation.sentinel
+   	Provider    : dnsimple/dnsimple
+   	Resource    : dnsimple_domain_delegation
+   	Parameter   : name_servers
+   	========================================================================
+   	For a list of allowed parameter options see:
+   	https://github.com/dnsimple/policy-library-dnsimple-terraform/blob/main/README.md
+
+  	========================================================================
+   	RESOURCE VIOLATIONS
+   	The domain name_servers should only include ns1.dnsimple.com, ns2.dnsimple.com, ns3.dnsimple.com, ns4.dnsimple.com, ns4.dnsimple-edge.org.
+   	========================================================================
+  	 name       : instance
+  	 type       : dnsimple_domain_delegation
+  	 address    : dnsimple_domain_delegation.test
+  	 message    : ns1.name-servers.com, ns2.dnsimple.com, ns1.gcp.com, ns1.aws.com is not an allowed name_servers set.
+   	------------------------------------------------------------------------
+  	 name       : instance
+  	 type       : dnsimple_domain_delegation
+  	 address    : dnsimple_domain_delegation.test_2
+  	 message    : ns1.name-servers.com, ns2.dnsimple.com is not an allowed name_servers set.
+   	------------------------------------------------------------------------
+  	 Resources out of compliance: 2
+   	------------------------------------------------------------------------
+trace:
+  enforce_domain_delegation.sentinel:77:1 - Rule "main"
+    Value:
+      false
+```

--- a/policies/enforce_auto_renew_state/test/enforce_auto_renew_state/failure-with-params.hcl
+++ b/policies/enforce_auto_renew_state/test/enforce_auto_renew_state/failure-with-params.hcl
@@ -8,7 +8,7 @@ import "module" "helpers" {
   source = "../../../../modules/helpers.sentinel"
 }
 
-param "transfer_lock_enforced_domain_names" {
+param "auto_renew_enforced_domain_names" {
   value = [
     "example-2.com"
   ]

--- a/policies/enforce_auto_renew_state/test/enforce_auto_renew_state/success-with-params.hcl
+++ b/policies/enforce_auto_renew_state/test/enforce_auto_renew_state/success-with-params.hcl
@@ -8,7 +8,7 @@ import "module" "helpers" {
   source = "../../../../modules/helpers.sentinel"
 }
 
-param "transfer_lock_enforced_domain_names" {
+param "auto_renew_enforced_domain_names" {
   value = [
     "example-2.com"
   ]

--- a/policies/enforce_dnssec_state/test/enforce_dnssec_state/success-with-domain-name-list-params.hcl
+++ b/policies/enforce_dnssec_state/test/enforce_dnssec_state/success-with-domain-name-list-params.hcl
@@ -8,7 +8,7 @@ import "module" "helpers" {
   source = "../../../../modules/helpers.sentinel"
 }
 
-param "whois_privacy_enforced_domain_names" {
+param "dnssec_enforced_domain_names" {
   value = [
     "example-2.eu"
   ]

--- a/policies/enforce_domain_delegation/enforce_domain_delegation.sentinel
+++ b/policies/enforce_domain_delegation/enforce_domain_delegation.sentinel
@@ -1,0 +1,79 @@
+import "tfplan/v2" as tfplan
+import "strings"
+import "helpers"
+
+param valid_actions default [
+	["no-op"],
+	["create"],
+	["update"],
+]
+
+// The enforced delegation records
+param allowed_delegation_records default [
+	"ns1.dnsimple.com",
+	"ns2.dnsimple.com",
+	"ns3.dnsimple.com",
+	"ns4.dnsimple.com",
+	"ns4.dnsimple-edge.org",
+]
+
+// A list of domain names that should have domain delegation enforced
+param domain_delegation_enforced_domain_names default []
+
+doc = {
+	"allowed":   allowed_delegation_records,
+	"error":     " is not an allowed name_servers set.",
+	"file_name": "enforce_domain_delegation.sentinel",
+	"name":      "Enforeced Domain Delegation",
+	"md_url":    "https://github.com/dnsimple/policy-library-dnsimple-terraform/blob/main/README.md",
+	"parameter": "name_servers",
+	"provider":  "dnsimple/dnsimple",
+	"resource":  "dnsimple_domain_delegation",
+	"violation": "The domain name_servers should only include " + strings.join(allowed_delegation_records, ", ") + ".",
+}
+
+// Filter resources by type
+all_resources = filter tfplan.resource_changes as _, rc {
+	rc.type is doc.resource and
+		rc.mode is "managed" and
+		rc.change.actions in valid_actions
+}
+
+// Check if all the delegation records are included in the name_servers
+all_delegation_records_included = func(name_servers) {
+	allowed = doc.allowed
+	for name_servers as _, ns {
+		if ns not in allowed {
+			return false
+		}
+	}
+	return true
+}
+
+if (length(domain_delegation_enforced_domain_names) else 0) > 0 {
+	all_resources = filter all_resources as _, r {
+		r.change.after.domain in domain_delegation_enforced_domain_names
+	}
+}
+
+// Filter resources that violate a given condition
+violators = filter all_resources as _, r {
+	all_delegation_records_included(r.change.after.name_servers) is false
+}
+
+// Build a summary report
+summaryreport = {
+	"name": doc.name,
+	"violations": map violators as _, violation {
+		{
+			"name":    violation.name,
+			"address": violation.address,
+			"type":    violation.type,
+			"message": strings.join(violation.change.after.name_servers, ", ") + doc.error,
+		}
+	},
+}
+
+main = rule {
+	helpers.summary(summaryreport, doc)
+}

--- a/policies/enforce_domain_delegation/test/enforce_domain_delegation/failure-with-params.hcl
+++ b/policies/enforce_domain_delegation/test/enforce_domain_delegation/failure-with-params.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-failure.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "domain_delegation_enforced_domain_names" {
+  value = [
+    "example-2.com"
+  ]
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/enforce_domain_delegation/test/enforce_domain_delegation/failure.hcl
+++ b/policies/enforce_domain_delegation/test/enforce_domain_delegation/failure.hcl
@@ -1,0 +1,15 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-failure.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+test {
+  rules = {
+    main = false
+  }
+}

--- a/policies/enforce_domain_delegation/test/enforce_domain_delegation/success-with-params.hcl
+++ b/policies/enforce_domain_delegation/test/enforce_domain_delegation/success-with-params.hcl
@@ -1,0 +1,21 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-success.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+param "domain_delegation_enforced_domain_names" {
+  value = [
+    "example-2.com"
+  ]
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/policies/enforce_domain_delegation/test/enforce_domain_delegation/success.hcl
+++ b/policies/enforce_domain_delegation/test/enforce_domain_delegation/success.hcl
@@ -1,0 +1,15 @@
+mock "tfplan/v2" {
+  module {
+    source = "../../testdata/mock-tfplan-success.sentinel"
+  }
+}
+
+import "module" "helpers" {
+  source = "../../../../modules/helpers.sentinel"
+}
+
+test {
+  rules = {
+    main = true
+  }
+}

--- a/policies/enforce_domain_delegation/testdata/mock-tfplan-failure.sentinel
+++ b/policies/enforce_domain_delegation/testdata/mock-tfplan-failure.sentinel
@@ -9,7 +9,7 @@ resource_changes = {
 			],
 			"after": {
 				"domain": "example.com",
-				"id": "example.com",
+				"id":     "example.com",
 				"name_servers": [
 					"ns1.name-servers.com",
 					"ns2.dnsimple.com",
@@ -34,7 +34,7 @@ resource_changes = {
 			],
 			"after": {
 				"domain": "example-2.com",
-				"id": "example-2.com",
+				"id":     "example-2.com",
 				"name_servers": [
 					"ns1.name-servers.com",
 					"ns2.dnsimple.com",

--- a/policies/enforce_domain_delegation/testdata/mock-tfplan-failure.sentinel
+++ b/policies/enforce_domain_delegation/testdata/mock-tfplan-failure.sentinel
@@ -1,0 +1,52 @@
+terraform_version = "1.5.6"
+
+resource_changes = {
+	"dnsimple_domain_delegation.test": {
+		"address": "dnsimple_domain_delegation.test",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"domain": "example.com",
+				"id": "example.com",
+				"name_servers": [
+					"ns1.name-servers.com",
+					"ns2.dnsimple.com",
+					"ns1.gcp.com",
+					"ns1.aws.com",
+				],
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_domain_delegation",
+	},
+	"dnsimple_domain_delegation.test_2": {
+		"address": "dnsimple_domain_delegation.test_2",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"domain": "example-2.com",
+				"id": "example-2.com",
+				"name_servers": [
+					"ns1.name-servers.com",
+					"ns2.dnsimple.com",
+				],
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_domain_delegation",
+	},
+}

--- a/policies/enforce_domain_delegation/testdata/mock-tfplan-success.sentinel
+++ b/policies/enforce_domain_delegation/testdata/mock-tfplan-success.sentinel
@@ -1,0 +1,52 @@
+terraform_version = "1.5.6"
+
+resource_changes = {
+	"dnsimple_domain_delegation.test": {
+		"address": "dnsimple_domain_delegation.test",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"domain": "example.com",
+				"id": "example.com",
+				"name_servers": [
+					"ns1.dnsimple.com",
+					"ns2.dnsimple.com",
+					"ns3.dnsimple.com",
+					"ns4.dnsimple-edge.org",
+				],
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_domain_delegation",
+	},
+	"dnsimple_domain_delegation.test_2": {
+		"address": "dnsimple_domain_delegation.test_2",
+		"change": {
+			"actions": [
+				"create",
+			],
+			"after": {
+				"domain": "example-2.com",
+				"id": "example-2.com",
+				"name_servers": [
+					"ns1.dnsimple.com",
+					"ns2.dnsimple.com",
+				],
+			},
+		},
+		"deposed":        "",
+		"index":          null,
+		"mode":           "managed",
+		"module_address": "module.dnsimple",
+		"name":           "instance",
+		"provider_name":  "registry.terraform.io/dnsimple/dnsimple",
+		"type":           "dnsimple_domain_delegation",
+	},
+}

--- a/policies/enforce_domain_delegation/testdata/mock-tfplan-success.sentinel
+++ b/policies/enforce_domain_delegation/testdata/mock-tfplan-success.sentinel
@@ -9,7 +9,7 @@ resource_changes = {
 			],
 			"after": {
 				"domain": "example.com",
-				"id": "example.com",
+				"id":     "example.com",
 				"name_servers": [
 					"ns1.dnsimple.com",
 					"ns2.dnsimple.com",
@@ -34,7 +34,7 @@ resource_changes = {
 			],
 			"after": {
 				"domain": "example-2.com",
-				"id": "example-2.com",
+				"id":     "example-2.com",
 				"name_servers": [
 					"ns1.dnsimple.com",
 					"ns2.dnsimple.com",

--- a/sentinel.hcl
+++ b/sentinel.hcl
@@ -27,3 +27,8 @@ policy "enforce_contact_id" {
   source = "./policies/enforce_contact_id/enforce_contact_id.sentinel"
   enforcement_level = "advisory"
 }
+
+policy "enforce_domain_delegation" {
+  source = "./policies/enforce_domain_delegation/enforce_domain_delegation.sentinel"
+  enforcement_level = "advisory"
+}


### PR DESCRIPTION
This PR introduces support for developers to enforce only vetted name servers as domain delegation records for the `dnsimple_domain_delegation` resource.